### PR TITLE
fix/Query keyword is deprecated, updated with chat keyword

### DIFF
--- a/hugging_tg_chatbot/huggingchat.py
+++ b/hugging_tg_chatbot/huggingchat.py
@@ -20,7 +20,7 @@ chatbot = hugchat.ChatBot(cookies=cookies.get_dict())
 def generate_response(message: str):
     """Generate a response to a message"""
     response_queue = ""
-    for resp in chatbot.query(
+    for resp in chatbot.chat(
         message,
         stream=True
     ):


### PR DESCRIPTION
I checked the `hugchat/hugchat.py` and on line 753 there is a new update mentioning; 
"**Deprecated**
        Please use `chat()`. The function will raise an error immediately."

`chat` function works the same, I tested and got an answer on my telegram bot.

![image](https://github.com/user-attachments/assets/1e4a8831-951f-46db-a1d1-16bb9088a78e)
